### PR TITLE
Add history viewer (Historian) support

### DIFF
--- a/PFCompArch.xcodeproj/project.pbxproj
+++ b/PFCompArch.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		5A1EFD8E23E880BF003BAA72 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EFD8D23E880BF003BAA72 /* Item.swift */; };
 		5A1EFD9123E88236003BAA72 /* ListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EFD9023E88236003BAA72 /* ListView.swift */; };
 		5A24093523F8466400C4D850 /* ListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A24093423F8466400C4D850 /* ListCell.swift */; };
+		5A410D7F2427B19D008C4A3C /* HistoryTransceiver in Frameworks */ = {isa = PBXBuildFile; productRef = 5A410D7E2427B19D008C4A3C /* HistoryTransceiver */; };
 		5A4A375E23E9D86200795403 /* CasePaths in Frameworks */ = {isa = PBXBuildFile; productRef = 5A4A375D23E9D86200795403 /* CasePaths */; };
 		5AF5F87423E400A50084E2D1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5F87323E400A50084E2D1 /* AppDelegate.swift */; };
 		5AF5F87623E400A50084E2D1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF5F87523E400A50084E2D1 /* SceneDelegate.swift */; };
@@ -58,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A410D7F2427B19D008C4A3C /* HistoryTransceiver in Frameworks */,
 				5A4A375E23E9D86200795403 /* CasePaths in Frameworks */,
 				5A0AA2C923F6C2C7003627AE /* CompArch in Frameworks */,
 			);
@@ -170,6 +172,7 @@
 			packageProductDependencies = (
 				5A4A375D23E9D86200795403 /* CasePaths */,
 				5A0AA2C823F6C2C7003627AE /* CompArch */,
+				5A410D7E2427B19D008C4A3C /* HistoryTransceiver */,
 			);
 			productName = PFCompArch;
 			productReference = 5AF5F87023E400A50084E2D1 /* PFCompArch.app */;
@@ -202,6 +205,7 @@
 			packageReferences = (
 				5A4A375C23E9D86200795403 /* XCRemoteSwiftPackageReference "swift-case-paths" */,
 				5A0AA2C723F6C2C7003627AE /* XCRemoteSwiftPackageReference "CompArch" */,
+				5A410D7D2427B19D008C4A3C /* XCRemoteSwiftPackageReference "HistoryTransceiver" */,
 			);
 			productRefGroup = 5AF5F87123E400A50084E2D1 /* Products */;
 			projectDirPath = "";
@@ -444,6 +448,14 @@
 				minimumVersion = 0.1.0;
 			};
 		};
+		5A410D7D2427B19D008C4A3C /* XCRemoteSwiftPackageReference "HistoryTransceiver" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/finestructure/HistoryTransceiver";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.4;
+			};
+		};
 		5A4A375C23E9D86200795403 /* XCRemoteSwiftPackageReference "swift-case-paths" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-case-paths.git";
@@ -459,6 +471,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5A0AA2C723F6C2C7003627AE /* XCRemoteSwiftPackageReference "CompArch" */;
 			productName = CompArch;
+		};
+		5A410D7E2427B19D008C4A3C /* HistoryTransceiver */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5A410D7D2427B19D008C4A3C /* XCRemoteSwiftPackageReference "HistoryTransceiver" */;
+			productName = HistoryTransceiver;
 		};
 		5A4A375D23E9D86200795403 /* CasePaths */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PFCompArch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PFCompArch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "git@github.com:finestructure/CompArch.git",
         "state": {
           "branch": null,
-          "revision": "b3bbb247b18b29549e905e31e5a19ebc46d1cefb",
-          "version": "0.7.2"
+          "revision": "4df83f97f8650a57fc08d016a90081ee61874568",
+          "version": "0.7.3"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/finestructure/HistoryTransceiver",
         "state": {
           "branch": null,
-          "revision": "5621f4dc442a5047b7ee8f0ee78538cfe9e0755e",
-          "version": "0.0.4"
+          "revision": "d90f8579bb3943f73e7d66f52228f017ea19c225",
+          "version": "0.0.6"
         }
       },
       {

--- a/PFCompArch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PFCompArch.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,24 @@
         }
       },
       {
+        "package": "HistoryTransceiver",
+        "repositoryURL": "https://github.com/finestructure/HistoryTransceiver",
+        "state": {
+          "branch": null,
+          "revision": "5621f4dc442a5047b7ee8f0ee78538cfe9e0755e",
+          "version": "0.0.4"
+        }
+      },
+      {
+        "package": "MultipeerKit",
+        "repositoryURL": "https://github.com/insidegui/MultipeerKit",
+        "state": {
+          "branch": null,
+          "revision": "3f430bc28e1426ba42cdaa8b19fb4d89ce6d1c3b",
+          "version": "0.1.2"
+        }
+      },
+      {
         "package": "CasePaths",
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths.git",
         "state": {

--- a/PFCompArch/ContentView.swift
+++ b/PFCompArch/ContentView.swift
@@ -100,16 +100,11 @@ extension ContentView.State: StateInitializable {
         self.indexedView = .init(items: items)
         self.listView = .init(items: items)
     }
-
-    init?(from data: Data) {
-        guard let state = try? JSONDecoder().decode(Self.self, from: data) else { return nil }
-        self = state
-    }
 }
 
 
 extension ContentView: StateSurfable {
-    static func body(store: Store<State, Action>) -> ContentView {
+    static func body(store: Store<State, Action>) -> Self {
         ContentView(store: store)
     }
 }

--- a/PFCompArch/ContentView.swift
+++ b/PFCompArch/ContentView.swift
@@ -8,6 +8,7 @@
 
 import CasePaths
 import CompArch
+import HistoryTransceiver
 import SwiftUI
 
 
@@ -89,3 +90,26 @@ struct ContentView_Previews: PreviewProvider {
     }
 }
 
+
+// MARK:- State surfing
+
+extension ContentView.State: StateInitializable {
+    init() {
+        let items: [Item] = [1, 2, 3]
+        self.identifiedView = .init(items: items)
+        self.indexedView = .init(items: items)
+        self.listView = .init(items: items)
+    }
+
+    init?(from data: Data) {
+        guard let state = try? JSONDecoder().decode(Self.self, from: data) else { return nil }
+        self = state
+    }
+}
+
+
+extension ContentView: StateSurfable {
+    static func body(store: Store<State, Action>) -> ContentView {
+        ContentView(store: store)
+    }
+}

--- a/PFCompArch/SceneDelegate.swift
+++ b/PFCompArch/SceneDelegate.swift
@@ -6,8 +6,13 @@
 //  Copyright © 2020 finestructure. All rights reserved.
 //
 
+import HistoryTransceiver
 import UIKit
 import SwiftUI
+
+
+var appStore = HistoryTransceiverView<ContentView>.store()
+
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -19,8 +24,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
 
+        Transceiver.shared.receive(Message.self) { msg in
+            if msg.command == .reset {
+                appStore.send(.updateState(msg.state))
+            }
+        }
+        Transceiver.shared.resume()
+
         // Create the SwiftUI view that provides the window contents.
-        let contentView = ContentView(store: ContentView.store(items: [1, 2, 3]))
+        let contentView = HistoryTransceiverView<ContentView>(store: appStore)
 
 
         // Use a UIHostingController as window root view controller.


### PR DESCRIPTION
This is an example PR to highlight the changes to integrate ["State Surfing"](https://twitter.com/_sa_s/status/1241771220451897353) into the example app.

<img width="1235" alt="Screenshot 2020-03-24 at 14 51 47" src="https://user-images.githubusercontent.com/65520/77433019-1c690280-6ddf-11ea-9d39-3d40874b899a.png">

The changes can be summarised as follows:

- Make `AppState` adopt the `StateInitializable` protocol (which is essentially `Codable`)
- Make `ContentView` adopt the `StateSurfable` protocol
- Replace `rootView: ContentView(...)` with `HistoryTransceiverView<ContentView>(...)` in `SceneDelegate` and start the transceiver

With those changes in place, the app will broadcast state changes. Use the [Historian app](https://github.com/finestructure/Historian) to view those changes and surf to any state.